### PR TITLE
feat: add helpers for valid and invalid values

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ yarn add parameter-reducers
 ## Usage
 
 ```ts
-import {parse, startChain, param} from 'parameter-reducers';
+import {parse, startChain, param, valid, invalid} from 'parameter-reducers';
 
 const globalParams = startChain()
   .addParam(param.flag(['-h', '--help'], 'help'))
@@ -22,12 +22,9 @@ const globalParams = startChain()
         case 'info':
         case 'warn':
         case 'error':
-          return {valid: true, value: str};
+          return valid(str);
         default:
-          return {
-            valid: false,
-            reason: `${key} should be one of debug, info, warn or error`,
-          };
+          return invalid(`${key} should be one of debug, info, warn or error`);
       }
     }),
   );

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,34 @@
+import {SuccessParameterReducerResult} from './types';
+
+export function valid<TParsed>(value: TParsed): {valid: true; value: TParsed};
+export function valid<TAlreadyParsed, TName extends string, TValue>(
+  alreadyParsedOrValue: TAlreadyParsed,
+  name: TName,
+  value: TValue,
+  rest: string[],
+): SuccessParameterReducerResult<{[name in TName]: TValue}, TAlreadyParsed>;
+export function valid<TAlreadyParsed, TName extends string, TValue>(
+  alreadyParsedOrValue: TAlreadyParsed,
+  name?: TName,
+  value?: TValue,
+  rest?: string[],
+):
+  | {valid: true; value: TAlreadyParsed}
+  | SuccessParameterReducerResult<{[name in TName]: TValue}, TAlreadyParsed> {
+  if (name === undefined && value === undefined && rest === undefined) {
+    return {valid: true, value: alreadyParsedOrValue};
+  }
+  // tslint:disable-next-line: strict-type-predicates
+  if (typeof name !== 'string') {
+    throw new Error('Expected name to be a string');
+  }
+  if (!Array.isArray(rest)) {
+    throw new Error('Expected rest to be an array');
+  }
+
+  return {valid: true, parsed: {...alreadyParsedOrValue, [name]: value}, rest};
+}
+
+export function invalid(reason: string): {valid: false; reason: string} {
+  return {valid: false, reason};
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {ParameterReducer} from './types';
 export {param};
 export {ParameterReducerResult, ParameterReducer} from './types';
 export {Chain, startChain} from './chain';
+export {valid, invalid} from './helpers';
 
 export function parse<T>(
   parameters: ParameterReducer<T>,

--- a/src/parameters.ts
+++ b/src/parameters.ts
@@ -1,4 +1,5 @@
 import {ParameterReducer} from '.';
+import {valid, invalid} from './helpers';
 
 export function flag<TName extends string>(
   keys: string[],
@@ -11,32 +12,21 @@ export function flag<TName extends string>(
     for (const key of keys) {
       if (input[0] === key) {
         if ((parsed as any)[name] !== undefined) {
-          return {
-            valid: false,
-            reason: `You have specified more than one value for ${key}`,
-          };
+          return invalid(`You have specified more than one value for ${key}`);
         }
-        return {
-          valid: true,
-          rest: input.slice(1),
-          parsed: {...parsed, [name]: true},
-        };
+        return valid(parsed, name, true, input.slice(1));
       }
     }
     if (shorthands.size && /^\-[a-z]+$/i.test(input[0])) {
       for (const s of input[0].substr(1).split('')) {
         if (shorthands.has(s)) {
           if ((parsed as any)[name] !== undefined) {
-            return {
-              valid: false,
-              reason: `You have specified more than one value for -${s}`,
-            };
+            return invalid(`You have specified more than one value for -${s}`);
           }
-          return {
-            valid: true,
-            rest: [input[0].replace(s, ''), ...input.slice(1)],
-            parsed: {...parsed, [name]: true},
-          };
+          return valid(parsed, name, true, [
+            input[0].replace(s, ''),
+            ...input.slice(1),
+          ]);
         }
       }
     }
@@ -58,21 +48,14 @@ export function parsedString<TName extends string, TParsed>(
     for (const key of keys) {
       if (input[0] === key) {
         if ((parsed as any)[name] !== undefined) {
-          return {
-            valid: false,
-            reason: `You have specified more than one value for ${key}`,
-          };
+          return invalid(`You have specified more than one value for ${key}`);
         }
         if (input.length < 2) {
-          return {valid: false, reason: `Missing string value for ${key}`};
+          return invalid(`Missing string value for ${key}`);
         }
         const result = parse(input[1], key);
         if (!result.valid) return result;
-        return {
-          valid: true,
-          rest: input.slice(2),
-          parsed: {...parsed, [name]: result.value},
-        };
+        return valid(parsed, name, result.value, input.slice(2));
       }
     }
     return undefined;
@@ -93,18 +76,16 @@ export function parsedStringList<TName extends string, TParsed>(
     for (const key of keys) {
       if (input[0] === key) {
         if (input.length < 2) {
-          return {valid: false, reason: `Missing string value for ${key}`};
+          return invalid(`Missing string value for ${key}`);
         }
         const result = parse(input[1], key);
         if (!result.valid) return result;
-        return {
-          valid: true,
-          rest: input.slice(2),
-          parsed: {
-            ...parsed,
-            [name]: [...((parsed as any)[name] || []), result.value],
-          },
-        };
+        return valid(
+          parsed,
+          name,
+          [...((parsed as any)[name] || []), result.value],
+          input.slice(2),
+        );
       }
     }
     return undefined;
@@ -115,17 +96,14 @@ export function string<TName extends string>(
   keys: string[],
   name: TName,
 ): ParameterReducer<{[name in TName]: string}> {
-  return parsedString(keys, name, (value) => ({valid: true, value}));
+  return parsedString(keys, name, (value) => valid(value));
 }
 
 export function stringList<TName extends string>(
   keys: string[],
   name: TName,
 ): ParameterReducer<{[name in TName]: string[]}> {
-  return parsedStringList(keys, name, (value) => ({
-    valid: true,
-    value,
-  }));
+  return parsedStringList(keys, name, (value) => valid(value));
 }
 
 export function integer<TName extends string>(
@@ -134,21 +112,15 @@ export function integer<TName extends string>(
 ): ParameterReducer<{[name in TName]: number}> {
   return parsedString(keys, name, (str, key) => {
     if (!/^\-?\d+$/.test(str)) {
-      return {valid: false, reason: `${key} must be an integer`};
+      return invalid(`${key} must be an integer`);
     }
     const value = parseInt(str, 10);
     if (value > Number.MAX_SAFE_INTEGER) {
-      return {
-        valid: false,
-        reason: `${key} is greater than the max safe integer`,
-      };
+      return invalid(`${key} is greater than the max safe integer`);
     }
     if (value < Number.MIN_SAFE_INTEGER) {
-      return {
-        valid: false,
-        reason: `${key} is less than the min safe integer`,
-      };
+      return invalid(`${key} is less than the min safe integer`);
     }
-    return {valid: true, value};
+    return valid(value);
   });
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,12 @@
+export type SuccessParameterReducerResult<T, S> = {
+  valid: true;
+  rest: string[];
+  parsed: Omit<S, keyof T> &
+    {[key in keyof T]?: T[key] | (key extends keyof S ? S[key] : never)};
+};
 export type ParameterReducerResult<T, S> =
   | undefined
-  | {
-      valid: true;
-      rest: string[];
-      parsed: Omit<S, keyof T> &
-        {[key in keyof T]?: T[key] | (key extends keyof S ? S[key] : never)};
-    }
+  | SuccessParameterReducerResult<T, S>
   | {valid: false; reason: string};
 export type ParameterReducer<TParsed> = <TAlreadyParsed>(
   input: string[],


### PR DESCRIPTION
Using these helpers provides marginally better type safety over just directly instantiating the objects, although that is also supported.